### PR TITLE
Update composer requirements for 8.2 release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,9 +6,8 @@
   "license": "MIT",
   "prefer-stable": true,
   "require": {
-    "composer/installers": "1.3.0",
-    "concrete5/core": "8.x-dev",
-    "illuminate/container": "5.2.*"
+    "composer/installers": "^1.3",
+    "concrete5/core": "^8.2"
   },
   "config": {
     "preferred-install": "dist"

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
   "name": "concrete5/composer",
   "description": "A fully featured skeleton for a composer managed concrete5 site",
   "type": "project",
-  "minimum-stability": "dev",
   "license": "MIT",
   "prefer-stable": true,
   "require": {


### PR DESCRIPTION
Now that c5 v8.2 is released, we can use stable versions of everything.