### PR TITLE
Track lockfiles in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,3 @@ public/application/files
 .idea
 node_modules
 .env
-
-# Stuff that's likely to change
-composer.lock
-yarn.lock
-mix-manifest.json


### PR DESCRIPTION
Not tracking `composer.lock` has burned us a couple of times. I think it's best to default to tracking the lock file and allow individuals to configure it how they want if needed.