### PR TITLE
keep doctrine/orm below 2.14

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "composer/installers": "^1.3",
     "concrete5/core": "^9.1",
     "concretecms/dependency-patches": "^1.4.0",
-    "vlucas/phpdotenv": "^2.4"
+    "vlucas/phpdotenv": "^2.4",
+    "doctrine/orm": "2.13.*"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.3|^8.0",


### PR DESCRIPTION
Concrete Core doesn't (yet) support 2.14 since the class name changed